### PR TITLE
feat: add KANBOARD_AUTH_METHOD=basic for Kanboard v1.2.52

### DIFF
--- a/main.go
+++ b/main.go
@@ -3112,6 +3112,21 @@ func (kc *kanboardClient) setAuthentication(req *http.Request) error {
 	// Determine authentication method based on available credentials
 	authMethod := strings.ToLower(strings.TrimSpace(os.Getenv("KANBOARD_AUTH_METHOD")))
 
+	// Explicit basic auth method: HTTP Basic Auth with username + password
+	// This is required by some Kanboard instances that don't support JSON-RPC body auth
+	if authMethod == "basic" {
+		if !kc.isValidCredentials() {
+			return fmt.Errorf("KANBOARD_AUTH_METHOD=basic requires valid KANBOARD_USERNAME and KANBOARD_PASSWORD")
+		}
+		auth := kc.username + ":" + kc.password
+		basicAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte(auth))
+		req.Header.Set("Authorization", basicAuth)
+		if os.Getenv("KANBOARD_DEBUG") == "true" {
+			fmt.Fprintf(os.Stderr, "DEBUG: Using HTTP Basic Auth (username:password)\n")
+		}
+		return nil
+	}
+
 	// Priority: API key over username/password
 	if kc.isValidAPIKey() {
 		switch authMethod {
@@ -3152,7 +3167,7 @@ func (kc *kanboardClient) setAuthentication(req *http.Request) error {
 			return nil
 
 		default:
-			return fmt.Errorf("unsupported KANBOARD_AUTH_METHOD: %s (supported: global_token, user_token, bearer)", authMethod)
+			return fmt.Errorf("unsupported KANBOARD_AUTH_METHOD: %s (supported: basic, global_token, user_token, bearer)", authMethod)
 		}
 	}
 


### PR DESCRIPTION
Kanboard v1.2.52 (latest) does not seem to accept API key authentication. The API key is valid (copied directly from the Kanboard UI) but all auth methods that use it fail:

| Method | Format | Result |
|--------|--------|--------|
| `global_token` | `jsonrpc:api_key` | 403 Forbidden |
| `user_token` | `username:api_key` | 401 Unauthorized |
| `bearer` | `Bearer api_key` | 401 Unauthorized |
| `basic` | `username:password` | **SUCCESS** |

Testing confirmed via curl:
- `curl -u "jsonrpc:<key>" getMe` → 403 Forbidden (key not recognized as valid token)
- `curl -u "username:<key>" getMe` → 401 Unauthorized
- `curl -H "Bearer <key>" getMe` → 401 Unauthorized
- `curl -u "username:password" getMe` → returns user profile successfully

## Solution

Adds an explicit `KANBOARD_AUTH_METHOD=basic` that uses `username:password` as HTTP Basic Auth. This is the only auth method that works with this Kanboard instance.

## Changes

- Added `basic` case to `setAuthentication()` — checks `isValidCredentials()` and sends `Basic <base64(username:password)>`
- Updated error message to list `basic` as a supported auth method
- Placed before the `isValidAPIKey()` block so it doesn't depend on API key being set

## Testing

- Binary compiled and installed locally
- Config tested with `"KANBOARD_AUTH_METHOD": "basic"` through OpenCode MCP integration
- All API calls (get_my_projects, etc.) return successfully

## Context

The `global_token` method sends `jsonrpc:<api_key>` which is the documented format for Kanboard's application tokens. However, Kanboard v1.2.52 rejects this format even with a valid API key. This suggests the API key authentication mechanism may have changed or is disabled by default in recent versions. The `basic` method provides a working alternative using username/password login.
